### PR TITLE
fix librocksdb link error

### DIFF
--- a/cmake/BuildRocksDB.cmake
+++ b/cmake/BuildRocksDB.cmake
@@ -22,7 +22,7 @@ macro(build_rocksdb)
 		DEPENDS ${PROJECT_BINARY_DIR}/db/rocksdb/librocksdb${CMAKE_SHARED_LIBRARY_SUFFIX}
 	)
 	message(STATUS "Use shipped RocksDB: ${PROJECT_SOURCE_DIR}/db/rocksdb")
-	set (ROCKSDB_LIBRARIES "${PROJECT_BINARY_DIR}/db/rocksdb/librocksdb${CMAKE_SHARED_LIBRARY_SUFFIX}" bz2 z lz4)
+	set (ROCKSDB_LIBRARIES "${PROJECT_BINARY_DIR}/db/rocksdb/librocksdb${CMAKE_SHARED_LIBRARY_SUFFIX}" bz2 z lz4 snappy)
 	set (ROCKSDB_FOUND 1)
 	add_dependencies(build_libs librocksdb)
 endmacro(build_rocksdb)


### PR DESCRIPTION
In latest RocksDB master branch code used libsnappy,  cause linking C executable ioarena  error. 
add snappy to ROCKSDB_LIBRARIES in cmake/BuildRocksDB.cmake can fix this bug. 