### PR TITLE
Macosx

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ IOARENA (embedded storage benchmarking)
 
 usage: ioarena [hDBCpnkvmlrwic]
   -D <database_driver>
-     choices: sophia, leveldb, rocksdb, wiredtiger, forestdb, lmdb, mdbx, sqlite3, iowow, dummy
+     choices: sophia, leveldb, rocksdb, wiredtiger, forestdb, lmdb, mdbx, sqlite3, iowow, dummy, unqlite
   -B <benchmarks>
      choices: set, get, delete, iterate, batch, crud
   -m <sync_mode>                     (default: lazy)

--- a/src/ia_kv.c
+++ b/src/ia_kv.c
@@ -9,6 +9,11 @@
 #include "ioarena.h"
 #include <math.h>
 
+#ifdef __APPLE__
+#include <architecture/byte_order.h>
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#endif
+
 /* #define DEBUG_KEYGEN 1 */
 
 #ifndef DEBUG_KEYGEN


### PR DESCRIPTION
I made a change in order to compile the code on Mac OS X. The change is related to htole64 which is not available on macosx. OSSwapHostToLittleInt64 should be used in place of it.