### PR TITLE
Support for specifying driver options via the `-o` command-line key

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ usage: ioarena [hDBCpnkvmlrwic]
      choices: sophia, leveldb, rocksdb, wiredtiger, forestdb, lmdb, mdbx, sqlite3, iowow, dummy, unqlite
   -B <benchmarks>
      choices: set, get, delete, iterate, batch, crud
+  -o <driver option>                 (default: none)
   -m <sync_mode>                     (default: lazy)
      choices: sync, lazy, nosync
   -l <wal_mode>                      (default: indef)

--- a/src/drivers/ia_debug.c
+++ b/src/drivers/ia_debug.c
@@ -118,10 +118,20 @@ static int ia_debug_next(iacontext *ctx, iabenchmark step, iakv *kv) {
   return rc;
 }
 
+static int ia_debug_option(iacontext *ctx, const char *arg) {
+  iadriver *drv = ioarena.driver;
+  printf("%s.option(%s %p, %s)\n", drv->name, ctx ? "doer" : "global", ctx,
+         arg);
+  if (strcmp(arg, "--help") == 0)
+    ia_log("`%s` driver don't support any option(s) except '%s'", "debug", arg);
+  return 0;
+}
+
 iadriver ia_debug = {.name = "debug",
                      .priv = NULL,
                      .open = ia_debug_open,
                      .close = ia_debug_close,
+                     .option = ia_debug_option,
 
                      .thread_new = ia_debug_thread_new,
                      .thread_dispose = ia_debug_thread_dispose,

--- a/src/drivers/ia_dummy.c
+++ b/src/drivers/ia_dummy.c
@@ -106,10 +106,20 @@ static int ia_dummy_next(iacontext *ctx, iabenchmark step, iakv *kv) {
   return rc;
 }
 
+static int ia_dummy_option(iacontext *ctx, const char *arg) {
+  iadriver *drv = ioarena.driver;
+  printf("%s.option(%s %p, %s)\n", drv->name, ctx ? "doer" : "global", ctx,
+         arg);
+  if (strcmp(arg, "--help") == 0)
+    ia_log("`%s` driver don't support any option(s) except '%s'", "dummy", arg);
+  return 0;
+}
+
 iadriver ia_dummy = {.name = "dummy",
                      .priv = NULL,
                      .open = ia_dummy_open,
                      .close = ia_dummy_close,
+                     .option = ia_dummy_option,
 
                      .thread_new = ia_dummy_thread_new,
                      .thread_dispose = ia_dummy_thread_dispose,

--- a/src/drivers/ia_mdbx.c
+++ b/src/drivers/ia_mdbx.c
@@ -17,6 +17,68 @@ struct iaprivate {
 
 #define INVALID_DBI ((MDBX_dbi)-1)
 
+struct mdbx_opts {
+  int8_t liforeclaim;
+  int8_t coalesce;
+  int8_t exclusive;
+  int8_t pageperturb;
+  int8_t nomeminit;
+  int8_t nordahead;
+  int8_t nometasync;
+};
+
+static struct mdbx_opts globals;
+
+static int ia_mdbx_option(iacontext *ctx, const char *arg) {
+  if (ctx)
+    return 0 /* no any non-global options */;
+
+  if (strcmp(arg, "--help") == 0) {
+    ia_log("  -o %s=<ON|OFF>", "LIFORECLAIM");
+    ia_log("  -o %s=<ON|OFF>", "COALESCE");
+    ia_log("  -o %s=<ON|OFF>", "EXCLUSIVE");
+    ia_log("  -o %s=<ON|OFF>", "PAGEPERTURB");
+    ia_log("  -o %s=<ON|OFF>", "NOMEMINIT");
+    ia_log("  -o %s=<ON|OFF>", "NORDAHEAD");
+    ia_log("  -o %s=<ON|OFF>", "NOMETASYNC");
+    return 0;
+  }
+
+  int parsed = ia_parse_option_bool(arg, "LIFORECLAIM", &globals.liforeclaim);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "COALESCE", &globals.coalesce);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "EXCLUSIVE", &globals.exclusive);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "PAGEPERTURB", &globals.pageperturb);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "NOMEMINIT", &globals.nomeminit);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "NORDAHEAD", &globals.nordahead);
+  if (!parsed)
+    parsed = ia_parse_option_bool(arg, "NOMETASYNC", &globals.nometasync);
+  if (parsed == 1)
+    return 0;
+
+  ia_log("%s: invalid option or value `%s`", "mdbx", arg);
+  return parsed ? parsed : -1;
+}
+
+static int peek_option_bool(int dflt, int opt, int8_t from) {
+  switch (from) {
+  default:
+    ia_log("error: invalid bool-option value %d", from);
+    ia_fatal(__func__);
+    /* fall through */
+  case ia_opt_bool_default:
+    return dflt;
+  case ia_opt_bool_off:
+    return dflt & ~opt;
+  case ia_opt_bool_on:
+    return dflt | opt;
+  }
+}
+
 struct iacontext {
   MDBX_txn *txn;
   MDBX_cursor *cursor;
@@ -81,6 +143,16 @@ static int ia_mdbx_open(const char *datadir) {
            ia_walmode2str(ioarena.conf.walmode));
     return -1;
   }
+
+  modeflags =
+      peek_option_bool(modeflags, MDBX_LIFORECLAIM, globals.liforeclaim);
+  modeflags = peek_option_bool(modeflags, MDBX_COALESCE, globals.coalesce);
+  modeflags = peek_option_bool(modeflags, MDBX_EXCLUSIVE, globals.exclusive);
+  modeflags =
+      peek_option_bool(modeflags, MDBX_PAGEPERTURB, globals.pageperturb);
+  modeflags = peek_option_bool(modeflags, MDBX_NOMEMINIT, globals.nomeminit);
+  modeflags = peek_option_bool(modeflags, MDBX_NORDAHEAD, globals.nordahead);
+  modeflags = peek_option_bool(modeflags, MDBX_NOMETASYNC, globals.nometasync);
 
   rc = mdbx_env_open(self->env, datadir, modeflags, 0644);
   if (rc != MDBX_SUCCESS)
@@ -340,6 +412,7 @@ iadriver ia_mdbx = {.name = "mdbx",
                     .priv = NULL,
                     .open = ia_mdbx_open,
                     .close = ia_mdbx_close,
+                    .option = ia_mdbx_option,
 
                     .thread_new = ia_mdbx_thread_new,
                     .thread_dispose = ia_mdbx_thread_dispose,

--- a/src/drivers/ia_mdbx.c
+++ b/src/drivers/ia_mdbx.c
@@ -44,24 +44,27 @@ static int ia_mdbx_option(iacontext *ctx, const char *arg) {
     return 0;
   }
 
-  int parsed = ia_parse_option_bool(arg, "LIFORECLAIM", &globals.liforeclaim);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "COALESCE", &globals.coalesce);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "EXCLUSIVE", &globals.exclusive);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "PAGEPERTURB", &globals.pageperturb);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "NOMEMINIT", &globals.nomeminit);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "NORDAHEAD", &globals.nordahead);
-  if (!parsed)
-    parsed = ia_parse_option_bool(arg, "NOMETASYNC", &globals.nometasync);
-  if (parsed == 1)
-    return 0;
+  int done = 0;
+  while (*arg && !done) {
+    done = ia_parse_option_bool(&arg, "LIFORECLAIM", &globals.liforeclaim);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "COALESCE", &globals.coalesce);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "EXCLUSIVE", &globals.exclusive);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "PAGEPERTURB", &globals.pageperturb);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "NOMEMINIT", &globals.nomeminit);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "NORDAHEAD", &globals.nordahead);
+    if (!done)
+      done = ia_parse_option_bool(&arg, "NOMETASYNC", &globals.nometasync);
+  }
 
+  if (done == 1)
+    return 0;
   ia_log("%s: invalid option or value `%s`", "mdbx", arg);
-  return parsed ? parsed : -1;
+  return done ? done : -1;
 }
 
 static int peek_option_bool(int dflt, int opt, int8_t from) {

--- a/src/drivers/ia_mdbx.c
+++ b/src/drivers/ia_mdbx.c
@@ -135,9 +135,13 @@ static int ia_mdbx_open(const char *datadir) {
 
   switch (ioarena.conf.walmode) {
   case IA_WAL_INDEF:
+    break;
   case IA_WAL_OFF:
+    modeflags &= ~MDBX_NOMETASYNC;
     break;
   case IA_WAL_ON:
+    modeflags |= MDBX_NOMETASYNC;
+    break;
   default:
     ia_log("error: %s(): unsupported walmode %s", __func__,
            ia_walmode2str(ioarena.conf.walmode));

--- a/src/ia.c
+++ b/src/ia.c
@@ -39,6 +39,16 @@ int ia_init(ia *a, int argc, char **argv) {
     return -1;
 
   a->before_open_ram = before_open.ram;
+  for (struct iaoption *drv_opt = a->conf.drv_opts; drv_opt;
+       drv_opt = drv_opt->next) {
+    rc = a->driver->option(NULL, drv_opt->arg);
+    if (rc) {
+      ia_log("error: driver '%s' reject/failed option `%s` globaly (error %d)",
+             a->driver->name, drv_opt->arg, rc);
+      return -1;
+    }
+  }
+
   rc = a->driver->open(a->datadir);
   if (rc == -1)
     return -1;

--- a/src/ia_benchmark.c
+++ b/src/ia_benchmark.c
@@ -169,6 +169,17 @@ int ia_doer_fulfil(iadoer *doer) {
       return -1;
   }
 
+  for (struct iaoption *drv_opt = ioarena.conf.drv_opts; drv_opt;
+       drv_opt = drv_opt->next) {
+    int rc = ioarena.driver->option(doer->ctx, drv_opt->arg);
+    if (rc) {
+      ia_log(
+          "error: driver '%s' reject/failed option `%s` for doer %d (error %d)",
+          ioarena.driver->name, drv_opt->arg, doer->nth, rc);
+      return -1;
+    }
+  }
+
   int count = 0, rc = 0;
   for (count = 0; count < ioarena.conf.nrepeat ||
                   (ioarena.conf.continuous_completing &&

--- a/src/ia_config.c
+++ b/src/ia_config.c
@@ -273,7 +273,8 @@ void ia_configprint(iaconfig *c) {
     ia_log("  r-threads    = %d", c->rthr);
   if (c->wthr)
     ia_log("  w-threads    = %d", c->wthr);
-  ia_log("  batch length = %d", c->batch_length);
+  if (ia_benchmark(c->benchmark) == IA_BATCH || c->benchmark_list[IA_BATCH])
+    ia_log("  batch length = %d", c->batch_length);
   ia_log("  continuous   = %s\n", c->continuous_completing ? "yes" : "no");
 }
 

--- a/src/ia_config.c
+++ b/src/ia_config.c
@@ -37,6 +37,11 @@ int ia_configinit(iaconfig *c) {
   c->walmode = IA_WAL_INDEF;
   c->continuous_completing = 0;
   c->nrepeat = 1;
+
+  c->kvseed = 42;
+  c->binary = 0;
+  c->separate = 0;
+  c->ignore_keynotfound = 0;
   return 0;
 }
 

--- a/src/ia_config.h
+++ b/src/ia_config.h
@@ -53,6 +53,6 @@ const char *ia_walmode2str(iawalmode walmode);
 #define ia_opt_bool_default 0
 #define ia_opt_bool_off -1
 #define ia_opt_bool_on 1
-int ia_parse_option_bool(const char *arg, const char *opt, int8_t *target);
+int ia_parse_option_bool(const char **parg, const char *opt, int8_t *target);
 
 #endif

--- a/src/ia_config.h
+++ b/src/ia_config.h
@@ -13,11 +13,17 @@ typedef struct iaconfig iaconfig;
 
 #include "ia_driver.h"
 
+struct iaoption {
+  const char *arg;
+  struct iaoption *next;
+};
+
 struct iaconfig {
   char *driver;
   iadriver *driver_if;
   char *path;
   char *benchmark;
+  struct iaoption *drv_opts;
   int benchmark_list[IA_MAX];
   int ksize;
   int vsize;
@@ -43,5 +49,10 @@ void ia_configfree(iaconfig *);
 
 const char *ia_syncmode2str(iasyncmode syncmode);
 const char *ia_walmode2str(iawalmode walmode);
+
+#define ia_opt_bool_default 0
+#define ia_opt_bool_off -1
+#define ia_opt_bool_on 1
+int ia_parse_option_bool(const char *arg, const char *opt, int8_t *target);
 
 #endif

--- a/src/ia_driver.h
+++ b/src/ia_driver.h
@@ -28,6 +28,7 @@ struct iadriver {
   int (*begin)(iacontext *, iabenchmark);
   int (*next)(iacontext *, iabenchmark, iakv *kv);
   int (*done)(iacontext *, iabenchmark);
+  int (*option)(iacontext *, const char *arg);
 };
 
 #endif


### PR DESCRIPTION
Я добавил возможность задавать произвольные параметры для драйверов посредством опции командной строки `-o`.
Затем задействовал добавленное в драйвере `libmdbx` ([пример использования](https://github.com/erthink/ioarena/blob/4d937cb754ff2ed654b5ccc148849284ab03ade2/runme.sh#L37-L49)).

На всякий гляньте эти правки и либо влейте, либо просто одобрите (тогда я волью сам).