### PR TITLE
Fix a building error under clang

### DIFF
--- a/src/ia_kv.c
+++ b/src/ia_kv.c
@@ -67,10 +67,10 @@ int ia_kvgen_setup(char printable, unsigned ksize, unsigned nspaces,
   } else if (maxkey < BITMASK(48)) {
     width = 48 / 8;
     top = BITMASK(48);
-  } else if (maxkey < BITMASK(56)) {
+  } else if (maxkey < (double) BITMASK(56)) {
     width = 56 / 8;
     top = BITMASK(56);
-  } else if (maxkey < UINT64_MAX) {
+  } else if (maxkey < (double) UINT64_MAX) {
     width = 64 / 8;
     top = UINT64_MAX;
   } else {


### PR DESCRIPTION
I saw the following building errors when building using clang.  This change fixes the issue by making conversion explicit. 

```
ioarena/src/ia_kv.c:70:23: error: implicit conversion from 'unsigned long' to 'double' changes value from 72057594037927935 to 72057594037927936 [-Werror,-Wimplicit-const-int-float-conversion]
```

```
ioarena/src/ia_kv.c:73:23: error: implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-const-int-float-conversion]
  } else if (maxkey < UINT64_MAX) {
                    ~ ^~~~~~~~~~
/usr/include/stdint.h:130:23: note: expanded from macro 'UINT64_MAX'
# define UINT64_MAX             (__UINT64_C(18446744073709551615))
                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/stdint.h:107:25: note: expanded from macro '__UINT64_C'
#  define __UINT64_C(c) c ## UL
                        ^~~~~~~
<scratch space>:145:1: note: expanded from here
18446744073709551615UL
^~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
```
