### PR TITLE
Update docs for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ usage: ioarena [hDBCpnkvmlrwic]
   -C <name-prefix> generate csv      (default: (null))
   -p <path> for temporaries          (default: ./_ioarena)
   -n <number_of_operations>          (default: 1000000)
-  -k <key_size>                      (default: 16)
-  -v <value_size>                    (default: 32)
+  -k <key_size>                      (default: 16 bytes)
+  -v <value_size>                    (default: 32 bytes)
   -c continuous completing mode      (default: no)
   -r <number_of_read_threads>        (default: 0)
      `zero` to use single main/common thread

--- a/src/ia_histogram.c
+++ b/src/ia_histogram.c
@@ -419,7 +419,7 @@ void ia_histogram_print(const iaconfig *config) {
     printf("----------------------------------------------------------\n");
 
     snpf_lat(line, sizeof(line), h->acc.latency_sum_ns);
-    printf("total:%16s  %16zu\n", line, n);
+    printf("total across all threads, latency:%8s, io_count:%8zu\n", line, n);
     snpf_lat(line, sizeof(line), h->whole_min);
     printf("min latency:%s/op\n", line);
     const ia_timestamp_t avg = h->acc.latency_sum_ns / h->acc.n;
@@ -435,7 +435,7 @@ void ia_histogram_print(const iaconfig *config) {
     const double wall = wall_ns / (double)S;
     const double rps = h->acc.n / wall;
     snpf_val(line, sizeof(line), rps, "");
-    printf(" throughput:%sops/s\n", line);
+    printf(" wall time: %8.3fs, throughput:%sops/s\n", wall, line);
 
     if (csv) {
       fprintf(csv, "\n%s,\t%s,\t%s,\t%s,\t%s\n", "ltn_min", "ltn_avg",
@@ -453,7 +453,7 @@ void ia_histogram_rusage(const iaconfig *config, const iarusage *start,
       "\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> rusage\n");
   FILE *csv = csv_create(config, "rusage");
 
-  printf("iops: read %ld, write %ld, page %ld\n",
+  printf("io_ops: read %ld, write %ld, page %ld\n",
          fihish->iops_read - start->iops_read,
          fihish->iops_write - start->iops_write,
          fihish->iops_page - start->iops_page);
@@ -467,8 +467,8 @@ void ia_histogram_rusage(const iaconfig *config, const iarusage *start,
          (fihish->ram - start->ram) / mb);
 
   if (csv) {
-    fprintf(csv, "%s,\t%s,\t%s,\t%s,\t%s,\t%s,\t%s\n", "iops_read",
-            "iops_write", "iops_page", "cpu_user_ns", "cpu_kernel_ns", "disk",
+    fprintf(csv, "%s,\t%s,\t%s,\t%s,\t%s,\t%s,\t%s\n", "io_reads",
+            "io_writes", "io_pages", "cpu_user_ns", "cpu_kernel_ns", "disk",
             "ram");
     fprintf(csv, "%ju,\t%ju,\t%ju,\t%e,\t%e,\t%e,\t%e\n",
             fihish->iops_read - start->iops_read,


### PR DESCRIPTION
- Rename `iops` to `io_ops`, since IOPS commonly means I/O operations per second, which does not match the actual semantics here.
- Rename `total` to `total across all threads` to avoid confusion with total wall time; the current value is an aggregate across threads, not elapsed time.
- Explicitly document the default size unit, as users may otherwise assume the value is in bits rather than bytes.